### PR TITLE
Fix Shortcut_Dimension_2_Code for Vendor accounts

### DIFF
--- a/process_japan_exports.py
+++ b/process_japan_exports.py
@@ -97,6 +97,14 @@ def create_journal_line(entry: Dict[str, Any], entry_type: str) -> Dict[str, Any
     # Determine ShortcutDimCode4 (vendor_code if present, otherwise applicant_code)
     shortcut_dim_code4 = entry_data.get("vendor_code", "") or entry_data.get("applicant_code", "")
     
+    # Determine Shortcut_Dimension_2_Code based on account type
+    # For Vendor accounts, use department_code which has the 9999 suffix
+    # For other accounts, use department as before
+    if entry_data.get("gl_account", "") == "Vendor":
+        shortcut_dim_2_code = entry_data.get("department_code", "")
+    else:
+        shortcut_dim_2_code = entry_data.get("department", "")
+    
     # Create the journal line payload
     journal_line = {
         "Journal_Template_Name": JOURNAL_TEMPLATE_NAME,
@@ -109,7 +117,7 @@ def create_journal_line(entry: Dict[str, Any], entry_type: str) -> Dict[str, Any
         "Currency_Code": entry_data.get("currency", ""),
         "Amount": amount,
         "Shortcut_Dimension_1_Code": entry_data.get("department", "")[:3] if entry_data.get("department") else "",
-        "Shortcut_Dimension_2_Code": entry_data.get("department", ""),
+        "Shortcut_Dimension_2_Code": shortcut_dim_2_code,
         "ShortcutDimCode3": "",
         "ShortcutDimCode4": shortcut_dim_code4,
         "ShortcutDimCode5": "",


### PR DESCRIPTION
## Description
This PR fixes the issue where Shortcut_Dimension_2_Code in the payload for "Account_Type": "Vendor" was not being set to the expected value with 9999 suffix.

## Changes
- Modified the `create_journal_line` function in `process_japan_exports.py` to use `department_code` instead of `department` for the Shortcut_Dimension_2_Code when the Account_Type is "Vendor"

Fixes #6