### PR TITLE
Add OAuth token helper and Postman guide

### DIFF
--- a/README_oauth_token.md
+++ b/README_oauth_token.md
@@ -1,0 +1,50 @@
+# OAuth Token Helper
+
+This utility helps with acquiring OAuth tokens from Microsoft Azure AD for integration with Microsoft Business Central API. It handles token acquisition and SSL certificate validation issues.
+
+## Features
+
+- OAuth 2.0 token acquisition using client credentials flow
+- SSL certificate validation handling
+- Detailed logging of token acquisition process
+- Helper methods for using tokens in API requests
+
+## Usage
+
+```python
+from oauth_token_helper import OAuthTokenHelper
+
+# Initialize with your credentials
+helper = OAuthTokenHelper(
+    tenant_id="your-tenant-id",
+    client_id="your-client-id",
+    client_secret="your-client-secret",
+    scope="https://api.businesscentral.dynamics.com/.default"
+)
+
+# Acquire a token
+token_data = helper.acquire_token()
+
+if token_data:
+    # Use the token for API requests
+    auth_header = helper.get_token_header()
+    # Make API requests with the auth_header
+```
+
+## SSL Certificate Issues
+
+If you encounter SSL certificate validation issues, you can temporarily disable SSL verification for development purposes:
+
+```python
+token_data = helper.acquire_token(verify_ssl=False)
+```
+
+**Note:** Disabling SSL verification is not recommended for production environments.
+
+## Logging
+
+The helper logs all token acquisition attempts and results to both a file and the console. Log files are named with the current date (e.g., `oauth_token_20250508.log`).
+
+## Related Issues
+
+This utility was created to address [Issue #16](https://github.com/yikuochan/Rakuimporter/issues/16) regarding OAuth token acquisition and SSL certificate validation problems.

--- a/README_postman_guide.md
+++ b/README_postman_guide.md
@@ -1,0 +1,92 @@
+# Using Postman to Verify OAuth Token Acquisition
+
+This guide explains how to use Postman to verify that you can acquire an OAuth token from Microsoft Azure AD for the VicOne app integration with Business Central API.
+
+## Prerequisites
+
+1. [Postman](https://www.postman.com/downloads/) installed on your computer
+2. VicOne app credentials:
+   - Client ID: 5d0ad744-0ae3-4712-b057-2cac7afb52f8
+   - Client Secret: (Your secret)
+   - Tenant ID: 6b83c27c-aa6d-475a-9933-5c34bb008d73
+
+## Step 1: Import the Collection
+
+1. Open Postman
+2. Click on "Import" in the top left corner
+3. Select the `VicOne_OAuth_Token_Collection.postman_collection.json` file
+4. Click "Import"
+
+## Step 2: Configure the Collection
+
+1. Replace `YOUR_CLIENT_SECRET_HERE` with your actual client secret in the "Get OAuth Token" request:
+   - Click on the "Get OAuth Token" request
+   - Go to the "Body" tab
+   - Find the "client_secret" key-value pair
+   - Replace `YOUR_CLIENT_SECRET_HERE` with your actual client secret
+
+2. Create a Postman Environment (optional but recommended):
+   - Click on the "Environments" tab in the left sidebar
+   - Click "Create Environment"
+   - Name it "VicOne Business Central"
+   - Add a variable named "access_token" (leave the value empty)
+   - Click "Save"
+
+## Step 3: Get an OAuth Token
+
+1. Select the "Get OAuth Token" request
+2. Click "Send"
+3. If successful, you should receive a response with:
+   - Status code: 200 OK
+   - JSON body containing:
+     - `access_token`: The OAuth token
+     - `token_type`: "Bearer"
+     - `expires_in`: Token expiration time in seconds
+     - Other fields
+
+4. The test script will automatically save the access token to the environment variable if you're using the environment.
+
+## Step 4: Test the Token with an API Request
+
+1. Update the "Test Business Central API" request:
+   - Replace `YOUR_COMPANY` in the URL with your actual company name or ID
+
+2. Select the "Test Business Central API" request
+3. Click "Send"
+4. If successful, you should receive a response with:
+   - Status code: 200 OK
+   - JSON body containing company data
+
+## Troubleshooting
+
+### SSL Certificate Issues
+
+If you encounter SSL certificate validation issues:
+
+1. Click on "Settings" (gear icon) in the top right
+2. Go to "General" tab
+3. Scroll down to "SSL Certificate Verification"
+4. Turn it OFF (Note: This is not recommended for production environments)
+5. Try the request again
+
+### Authentication Errors
+
+If you receive a 401 Unauthorized error:
+
+1. Verify your client ID and client secret are correct
+2. Check that the tenant ID in the URL is correct
+3. Ensure the scope is correct for your application
+
+### Other Issues
+
+If you encounter other issues:
+
+1. Check the response body for error details
+2. Verify network connectivity
+3. Ensure your Azure AD application has the necessary permissions
+
+## Related Resources
+
+- [OAuth Token Helper Script](./oauth_token_helper.py): Python script for token acquisition
+- [Test OAuth Token Script](./test_oauth_token.py): Script to test token acquisition and API access
+- [GitHub Issue #16](https://github.com/yikuochan/Rakuimporter/issues/16): Related issue tracking this problem

--- a/VicOne_OAuth_Token_Collection.postman_collection.json
+++ b/VicOne_OAuth_Token_Collection.postman_collection.json
@@ -1,0 +1,133 @@
+{
+	"info": {
+		"_postman_id": "7e8f9a10-5d6b-4c3e-8f7a-2b3c4d5e6f7g",
+		"name": "VicOne OAuth Token Collection",
+		"description": "A collection for testing OAuth token acquisition from Microsoft Azure AD for VicOne app integration with Business Central API.",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Get OAuth Token",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/x-www-form-urlencoded"
+					}
+				],
+				"body": {
+					"mode": "urlencoded",
+					"urlencoded": [
+						{
+							"key": "grant_type",
+							"value": "client_credentials",
+							"type": "text"
+						},
+						{
+							"key": "client_id",
+							"value": "5d0ad744-0ae3-4712-b057-2cac7afb52f8",
+							"type": "text"
+						},
+						{
+							"key": "client_secret",
+							"value": "YOUR_CLIENT_SECRET_HERE",
+							"type": "text"
+						},
+						{
+							"key": "scope",
+							"value": "https://api.businesscentral.dynamics.com/.default",
+							"type": "text"
+						}
+					]
+				},
+				"url": {
+					"raw": "https://login.microsoftonline.com/6b83c27c-aa6d-475a-9933-5c34bb008d73/oauth2/v2.0/token",
+					"protocol": "https",
+					"host": [
+						"login",
+						"microsoftonline",
+						"com"
+					],
+					"path": [
+						"6b83c27c-aa6d-475a-9933-5c34bb008d73",
+						"oauth2",
+						"v2.0",
+						"token"
+					]
+				},
+				"description": "Acquires an OAuth token from Microsoft Azure AD using client credentials flow."
+			},
+			"response": []
+		},
+		{
+			"name": "Test Business Central API",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{access_token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "https://api.businesscentral.dynamics.com/v2.0/YOUR_COMPANY/api/v2.0/companies",
+					"protocol": "https",
+					"host": [
+						"api",
+						"businesscentral",
+						"dynamics",
+						"com"
+					],
+					"path": [
+						"v2.0",
+						"YOUR_COMPANY",
+						"api",
+						"v2.0",
+						"companies"
+					]
+				},
+				"description": "Tests the acquired token by making a request to the Business Central API."
+			},
+			"response": []
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					"// For the token request, save the access token to a variable",
+					"if (pm.response.code === 200 && pm.info.requestName === \"Get OAuth Token\") {",
+					"    var jsonData = pm.response.json();",
+					"    if (jsonData.access_token) {",
+					"        pm.environment.set(\"access_token\", jsonData.access_token);",
+					"        console.log(\"Access token saved to environment variable\");",
+					"    }",
+					"}"
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "access_token",
+			"value": ""
+		}
+	]
+}

--- a/oauth_token_helper.py
+++ b/oauth_token_helper.py
@@ -1,0 +1,138 @@
+import requests
+import json
+import logging
+from datetime import datetime
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.FileHandler(f"oauth_token_{datetime.now().strftime('%Y%m%d')}.log"),
+        logging.StreamHandler()
+    ]
+)
+logger = logging.getLogger("oauth_token_helper")
+
+class OAuthTokenHelper:
+    """
+    Helper class for acquiring OAuth tokens from Microsoft Azure AD
+    and handling SSL certificate validation.
+    """
+    
+    def __init__(self, tenant_id, client_id, client_secret, scope):
+        """
+        Initialize the OAuth token helper with the required credentials.
+        
+        Args:
+            tenant_id (str): The Azure AD tenant ID
+            client_id (str): The client ID (application ID)
+            client_secret (str): The client secret
+            scope (str): The requested scope
+        """
+        self.tenant_id = tenant_id
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.scope = scope
+        self.token_url = f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
+        self.token = None
+        self.token_expiry = None
+    
+    def acquire_token(self, verify_ssl=True):
+        """
+        Acquire an OAuth token from Microsoft Azure AD.
+        
+        Args:
+            verify_ssl (bool): Whether to verify SSL certificates
+            
+        Returns:
+            dict: The token response or None if acquisition failed
+        """
+        try:
+            logger.info(f"Acquiring token for client ID: {self.client_id}")
+            
+            payload = {
+                'grant_type': 'client_credentials',
+                'client_id': self.client_id,
+                'client_secret': self.client_secret,
+                'scope': self.scope
+            }
+            
+            headers = {
+                'Content-Type': 'application/x-www-form-urlencoded'
+            }
+            
+            response = requests.post(
+                self.token_url,
+                data=payload,
+                headers=headers,
+                verify=verify_ssl
+            )
+            
+            if response.status_code == 200:
+                token_data = response.json()
+                logger.info("Token acquired successfully")
+                self.token = token_data
+                return token_data
+            else:
+                logger.error(f"Failed to acquire token. Status code: {response.status_code}")
+                logger.error(f"Response: {response.text}")
+                return None
+                
+        except requests.exceptions.SSLError as ssl_err:
+            logger.error(f"SSL Certificate Error: {str(ssl_err)}")
+            logger.info("Try setting verify_ssl=False if you're in a development environment")
+            return None
+            
+        except Exception as e:
+            logger.error(f"Error acquiring token: {str(e)}")
+            return None
+    
+    def get_token_header(self):
+        """
+        Get the Authorization header value for API requests.
+        
+        Returns:
+            str: The Authorization header value or None if no token is available
+        """
+        if self.token and 'access_token' in self.token:
+            return f"Bearer {self.token['access_token']}"
+        return None
+
+
+def main():
+    """
+    Example usage of the OAuthTokenHelper class.
+    """
+    # VicOne app credentials
+    tenant_id = "6b83c27c-aa6d-475a-9933-5c34bb008d73"
+    client_id = "5d0ad744-0ae3-4712-b057-2cac7afb52f8"
+    client_secret = "YOUR_CLIENT_SECRET_HERE"  # Replace with actual secret
+    scope = "https://api.businesscentral.dynamics.com/.default"
+    
+    # Create the helper
+    helper = OAuthTokenHelper(tenant_id, client_id, client_secret, scope)
+    
+    # Try to acquire a token with SSL verification
+    logger.info("Attempting to acquire token with SSL verification...")
+    token_data = helper.acquire_token(verify_ssl=True)
+    
+    if token_data:
+        logger.info("Token acquired successfully with SSL verification")
+        logger.info(f"Token type: {token_data.get('token_type')}")
+        logger.info(f"Expires in: {token_data.get('expires_in')} seconds")
+    else:
+        # If SSL verification fails, try without it (for development only)
+        logger.warning("Attempting to acquire token without SSL verification (DEVELOPMENT ONLY)...")
+        token_data = helper.acquire_token(verify_ssl=False)
+        
+        if token_data:
+            logger.info("Token acquired successfully without SSL verification")
+            logger.info(f"Token type: {token_data.get('token_type')}")
+            logger.info(f"Expires in: {token_data.get('expires_in')} seconds")
+        else:
+            logger.error("Failed to acquire token with and without SSL verification")
+
+
+if __name__ == "__main__":
+    main()

--- a/test_oauth_token.py
+++ b/test_oauth_token.py
@@ -1,0 +1,74 @@
+import requests
+import json
+from oauth_token_helper import OAuthTokenHelper
+import logging
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("test_oauth_token")
+
+def test_token_acquisition():
+    """
+    Test OAuth token acquisition and make a simple API request
+    to verify the token works.
+    """
+    # VicOne app credentials
+    tenant_id = "6b83c27c-aa6d-475a-9933-5c34bb008d73"
+    client_id = "5d0ad744-0ae3-4712-b057-2cac7afb52f8"
+    client_secret = "YOUR_CLIENT_SECRET_HERE"  # Replace with actual secret
+    scope = "https://api.businesscentral.dynamics.com/.default"
+    
+    # Create the helper
+    helper = OAuthTokenHelper(tenant_id, client_id, client_secret, scope)
+    
+    # Try to acquire a token
+    logger.info("Testing token acquisition...")
+    token_data = helper.acquire_token()
+    
+    if not token_data:
+        logger.error("Failed to acquire token. Test failed.")
+        return False
+    
+    logger.info("Token acquired successfully!")
+    logger.info(f"Token type: {token_data.get('token_type')}")
+    logger.info(f"Expires in: {token_data.get('expires_in')} seconds")
+    
+    # Get the authorization header
+    auth_header = helper.get_token_header()
+    if not auth_header:
+        logger.error("Failed to get authorization header. Test failed.")
+        return False
+    
+    # Test making an API request
+    try:
+        logger.info("Testing API request with the acquired token...")
+        
+        # Example API endpoint - replace with an actual Business Central endpoint
+        api_url = "https://api.businesscentral.dynamics.com/v2.0/YOUR_COMPANY/api/v2.0/companies"
+        
+        headers = {
+            "Authorization": auth_header,
+            "Content-Type": "application/json"
+        }
+        
+        response = requests.get(api_url, headers=headers)
+        
+        if response.status_code == 200:
+            logger.info("API request successful!")
+            logger.info(f"Response: {json.dumps(response.json(), indent=2)}")
+            return True
+        else:
+            logger.error(f"API request failed with status code: {response.status_code}")
+            logger.error(f"Response: {response.text}")
+            return False
+            
+    except Exception as e:
+        logger.error(f"Error making API request: {str(e)}")
+        return False
+
+if __name__ == "__main__":
+    success = test_token_acquisition()
+    if success:
+        logger.info("All tests passed successfully!")
+    else:
+        logger.error("Tests failed. Check the logs for details.")


### PR DESCRIPTION
## Description

This PR adds tools and documentation to help with OAuth token acquisition from Microsoft Azure AD for integration with Microsoft Business Central API. It addresses [Issue #16](https://github.com/yikuochan/Rakuimporter/issues/16) regarding OAuth token acquisition and SSL certificate validation problems.

## Changes

- Added `oauth_token_helper.py`: A Python class for acquiring OAuth tokens with SSL certificate validation handling
- Added `test_oauth_token.py`: A script to test token acquisition and API access
- Added `README_oauth_token.md`: Documentation for the OAuth token helper
- Added `README_postman_guide.md`: Step-by-step guide for using Postman to verify token acquisition
- Added `VicOne_OAuth_Token_Collection.postman_collection.json`: A ready-to-use Postman collection for testing

## How to Test

1. Import the Postman collection
2. Follow the instructions in the README_postman_guide.md file
3. Run the test_oauth_token.py script (replace the client secret first)

## Related Issues

Resolves #16