### PR TITLE
Fix ShortcutDimCode4 logic for debit lines in vendor payments

### DIFF
--- a/process_japan_exports.py
+++ b/process_japan_exports.py
@@ -101,6 +101,8 @@ SCOPE = get_env_var(
 
 # Fixed values for journal entries
 JOURNAL_TEMPLATE_NAME = "PURCHASES"
+# for Employee expense Journal , we can set journal batch name to GEE
+# JOURNAL_BATCH_NAME = "GEE"
 JOURNAL_BATCH_NAME = "PURCHASE"
 DOCUMENT_TYPE = "Invoice"
 
@@ -352,10 +354,15 @@ def create_journal_line(entry: Dict[str, Any], entry_type: str) -> Dict[str, Any
     # logger.info(f"Added voucher number to description: {description}")
     
     # Determine ShortcutDimCode4 based on account type and source of account_no
-    if entry_data.get("gl_account", "") == "Vendor":
-        # For Vendor accounts, check the source of account_no
-        if entry_data.get("vendor_code") and entry_data.get("account") == entry_data.get("vendor_code"):
-            # If account_no comes from column O (支払先CD), set ShortcutDimCode4 to empty
+    if entry_data.get("gl_account", "") == "Vendor" or entry.get("credit", {}).get("gl_account", "") == "Vendor":
+        # For Vendor accounts or entries with Vendor credit, check the source of account_no
+        # For debit lines of vendor payments, we need to check the credit side's account_source
+        if entry_type == "debit" and entry.get("credit", {}).get("account_source") == "vendor_code":
+            # If the credit side's account_no comes from column O (支払先CD), set ShortcutDimCode4 to empty
+            shortcut_dim_code4 = ""
+            logger.info(f"Setting ShortcutDimCode4 to empty for debit line of Vendor payment (支払先CD) - Voucher: {entry.get('voucher_no', 'Unknown')}")
+        elif entry_type == "credit" and entry_data.get("account_source") == "vendor_code":
+            # If the credit side's account_no comes from column O (支払先CD), set ShortcutDimCode4 to empty
             shortcut_dim_code4 = ""
             logger.info(f"Setting ShortcutDimCode4 to empty for Vendor payment (支払先CD) - Voucher: {entry.get('voucher_no', 'Unknown')}")
         else:


### PR DESCRIPTION
## Description

This PR fixes the ShortcutDimCode4 logic for debit lines in vendor payments. According to the requirements in issue #61, when account type is vendor and account_no comes from column O (支払先CD), ShortcutDimCode4 should be empty for both debit and credit lines.

The current implementation only applies this logic correctly to credit lines, while debit lines still have ShortcutDimCode4 set to the applicant_code value.

## Changes

Updated the ShortcutDimCode4 determination logic in the `create_journal_line` function in `process_japan_exports.py` to check the credit side's account_source field for debit lines of vendor payments. This ensures that when a vendor payment uses column O as the source, ShortcutDimCode4 is empty for both debit and credit lines as required.

## Testing

Tested with the VPA-0000092 voucher from the 0523-Raku export-VCT GE-1.utf8.csv file to verify that ShortcutDimCode4 is now correctly set to empty for both debit and credit lines when the vendor payment uses column O as the source.

Fixes #64